### PR TITLE
[ES-101]: Add support for storing media files in AWS S3

### DIFF
--- a/linkedevents/media_storage.py
+++ b/linkedevents/media_storage.py
@@ -1,0 +1,9 @@
+from storages.backends.s3boto3 import S3Boto3Storage
+from django.conf import settings
+
+
+class MediaStorage(S3Boto3Storage):
+    bucket_name = getattr(settings, 'AWS_MEDIA_STORAGE_BUCKET_NAME')
+    default_acl = getattr(settings, 'AWS_MEDIA_DEFAULT_ACL')
+    # The S3 files are served through nginx so we need to set the correct domain and path
+    custom_domain = getattr(settings, 'AWS_MEDIA_S3_CUSTOM_DOMAIN')

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -59,9 +59,13 @@ env = environ.Env(
     EXTRA_INSTALLED_APPS=(list, []),
     AUTO_ENABLED_EXTENSIONS=(list, []),
     STATICFILES_STORAGE=(str, 'django.contrib.staticfiles.storage.StaticFilesStorage'),
-    AWS_STORAGE_BUCKET_NAME=(str, ''),
-    AWS_DEFAULT_ACL=(str, None),
-    AWS_S3_CUSTOM_DOMAIN=(str, ''),
+    AWS_STATIC_STORAGE_BUCKET_NAME=(str, ''),
+    AWS_STATIC_DEFAULT_ACL=(str, None),
+    AWS_STATIC_S3_CUSTOM_DOMAIN=(str, ''),
+    DEFAULT_FILE_STORAGE=(str, 'django.core.files.storage.FileSystemStorage'),
+    AWS_MEDIA_STORAGE_BUCKET_NAME=(str, ''),
+    AWS_MEDIA_DEFAULT_ACL=(str, None),
+    AWS_MEDIA_S3_CUSTOM_DOMAIN=(str, ''),
 )
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -220,14 +224,26 @@ MEDIA_URL = env('MEDIA_URL')
 STATIC_ROOT = env('STATIC_ROOT')
 MEDIA_ROOT = env('MEDIA_ROOT')
 
+
+# Configure django-storages for static files
 STATICFILES_STORAGE = env('STATICFILES_STORAGE')
-AWS_STORAGE_BUCKET_NAME = env('AWS_STORAGE_BUCKET_NAME')
-# Let the files inherit the bucket's ACL
-AWS_DEFAULT_ACL = env('AWS_DEFAULT_ACL')
+AWS_STORAGE_BUCKET_NAME = env('AWS_STATIC_STORAGE_BUCKET_NAME')
+AWS_DEFAULT_ACL = env('AWS_STATIC_DEFAULT_ACL')
+# The S3 files are served through nginx so we need to set the correct domain and path
+AWS_S3_CUSTOM_DOMAIN = env('AWS_STATIC_S3_CUSTOM_DOMAIN')
+
+# Configure django-storages for media files
+# The other configuration options are defined in media_storage.py. See:
+# https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#overriding-the-default-storage-class
+DEFAULT_FILE_STORAGE = env('DEFAULT_FILE_STORAGE')
+AWS_MEDIA_STORAGE_BUCKET_NAME = env('AWS_MEDIA_STORAGE_BUCKET_NAME')
+AWS_MEDIA_DEFAULT_ACL = env('AWS_MEDIA_DEFAULT_ACL')
+# The S3 files are served through nginx so we need to set the correct domain and path
+AWS_MEDIA_S3_CUSTOM_DOMAIN = env('AWS_MEDIA_S3_CUSTOM_DOMAIN')
+
+# Settings common to both static files and media files
 # Do not append AWS query parameters to the generated URL
 AWS_QUERYSTRING_AUTH = False
-# The S3 files are served through nginx so we need to set the correct domain and path
-AWS_S3_CUSTOM_DOMAIN = env('AWS_S3_CUSTOM_DOMAIN')
 
 #
 # Authentication


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

[ES-101]

#### Dependencies
<!-- Describe the dependencies the change has on other repositories, pull requests etc. -->

#### Testing instructions
<!-- Describe how the change can be tested, e.g., steps and tools to use -->

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)
- [x] The commits and commit messages adhere to [version control conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
- [ ] ~The API's adhere to Voltti's REST API conventions~
- [x] The code is consistent with the existing code base
- [ ] ~Tests have been written for the change (unit, REST API)~
- [x] All tests pass
- [x] All code has been linted and there aren't any lint errors
- [x] The change has been tested locally, e.g., with httpie
- [ ] ~The change has been tested against a DB dump from test and/or staging if the models have been changed~
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)
- [ ] The commits and commit messages adhere to [version control conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
- [ ] The API's adhere to Voltti's REST API conventions
- [ ] The code is consistent with the existing code base
- [ ] All changes in all changed files have been reviewed
- [ ] Tests have been written for the change (unit, REST API)
- [ ] All tests pass
- [ ] All code has been linted and there aren't any lint errors
- [ ] The change has been tested locally, e.g., with httpie
- [ ] The change has been tested against a DB dump from test and/or staging if the models have been changed
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```


[ES-101]: https://voltti.atlassian.net/browse/ES-101