### PR TITLE
[ES-131]: Fix session for multiple instances

### DIFF
--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -496,9 +496,11 @@ if os.path.exists(f):
     sys.modules[module_name] = module
     exec(open(f, "rb").read())
 
-# We generate a persistent SECRET_KEY if it is not defined. Note that
+SECRET_KEY = env('SECRET_KEY')
+
+# We generate a persistent SECRET_KEY if it is not defined or it's empty. Note that
 # setting SECRET_KEY will override the persisted key
-if 'SECRET_KEY' not in locals():
+if 'SECRET_KEY' not in locals() or not SECRET_KEY:
     secret_file = os.path.join(BASE_DIR, '.django_secret')
     try:
         SECRET_KEY = open(secret_file).read().strip()


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

[ES-131]

#### Dependencies
<!-- Describe the dependencies the change has on other repositories, pull requests etc. -->

#### Testing instructions
<!-- Describe how the change can be tested, e.g., steps and tools to use -->

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)
- [x] The commits and commit messages adhere to [version control conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
- [ ] ~The API's adhere to Voltti's REST API conventions~
- [x] The code is consistent with the existing code base
- [ ] ~Tests have been written for the change (unit, REST API)~
- [x] All tests pass
- [x] All code has been linted and there aren't any lint errors
- [x] The change has been tested locally, e.g., with httpie
- [ ] ~The change has been tested against a DB dump from test and/or staging if the models have been changed~
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)
- [ ] The commits and commit messages adhere to [version control conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
- [ ] The API's adhere to Voltti's REST API conventions
- [ ] The code is consistent with the existing code base
- [ ] All changes in all changed files have been reviewed
- [ ] Tests have been written for the change (unit, REST API)
- [ ] All tests pass
- [ ] All code has been linted and there aren't any lint errors
- [ ] The change has been tested locally, e.g., with httpie
- [ ] The change has been tested against a DB dump from test and/or staging if the models have been changed
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```


[ES-131]: https://voltti.atlassian.net/browse/ES-131