### PR TITLE
[ES-135]: Fix hostnames in browsable API

### DIFF
--- a/linkedevents/middleware.py
+++ b/linkedevents/middleware.py
@@ -1,0 +1,40 @@
+from django.conf import settings
+from django.utils.deprecation import MiddlewareMixin
+
+
+class AwsAlbHeaderMiddleware(MiddlewareMixin):
+    def _transform_header_to_django_format(self, header):
+        return 'HTTP_{}'.format(header.upper().replace('-', '_'))
+
+    def process_request(self, request):
+        """Replaces X-Forwarded-{Port|Proto} headers with values from other custom headers
+
+        AWS load balancers overwrite the X-Forwarded-{Port|Proto} headers so setting them in a reverse proxy has no
+        effect. To overcome this, we can set custom headers in the reverse proxy and copy the X-Forwarded-{Port|Proto}
+        header values from these custom headers.
+
+        See https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html.
+
+        You can define the custom header names as environment variables, e.g.:
+
+            CUSTOM_X_FORWARDED_PORT_HEADER=LINKEDEVENTS-X-FORWARDED-PORT
+            CUSTOM_X_FORWARDED_PROTO_HEADER=LINKEDEVENTS-X-FORWARDED-PROTO
+
+        The middleware will take care of transforming the header names to forms understood by Django, e.g.:
+
+            LINKEDEVENTS-X-FORWARDED-PORT -> HTTP_LINKEDEVENTS_X_FORWARDED_PORT
+            LINKEDEVENTS-X-FORWARDED-PROTO -> HTTP_LINKEDEVENTS_X_FORWARDED_PROTO
+        """
+        custom_x_forwarded_port_header = getattr(settings, 'CUSTOM_X_FORWARDED_PORT_HEADER')
+        if custom_x_forwarded_port_header:
+            corrected_x_forwarded_port_header = self._transform_header_to_django_format(custom_x_forwarded_port_header)
+            x_forwarded_port = request.META.get(corrected_x_forwarded_port_header, '')
+            request.META['HTTP_X_FORWARDED_PORT'] = x_forwarded_port
+
+        custom_x_forwarded_proto_header = getattr(settings, 'CUSTOM_X_FORWARDED_PROTO_HEADER')
+        if custom_x_forwarded_proto_header:
+            corrected_x_forwarded_proto_header = self._transform_header_to_django_format(
+                custom_x_forwarded_proto_header
+            )
+            x_forwarded_proto = request.META.get(corrected_x_forwarded_proto_header, '')
+            request.META['HTTP_X_FORWARDED_PROTO'] = x_forwarded_proto

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -48,6 +48,7 @@ env = environ.Env(
     ALLOWED_HOSTS=(list, []),
     ADMINS=(list, []),
     SECURE_PROXY_SSL_HEADER=(tuple, None),
+    USE_X_FORWARDED_HOST=(bool, False),
     MEDIA_ROOT=(environ.Path(), root('media')),
     STATIC_ROOT=(environ.Path(), root('static')),
     MEDIA_URL=(str, '/media/'),
@@ -277,6 +278,20 @@ AWS_MEDIA_S3_CUSTOM_DOMAIN = env('AWS_MEDIA_S3_CUSTOM_DOMAIN')
 # Settings common to both static files and media files
 # Do not append AWS query parameters to the generated URL
 AWS_QUERYSTRING_AUTH = False
+
+# A boolean that specifies whether to use the X-Forwarded-Host header in preference to the Host header. This should
+# only be enabled if a proxy which sets this header is in use. If a proxy is in use and this is disabled, the links in
+# the Browsable API will be wrong.
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#use-x-forwarded-host
+USE_X_FORWARDED_HOST = env('USE_X_FORWARDED_HOST')
+
+# A tuple representing a HTTP header/value combination that signifies a request is secure. This controls the behavior
+# of the request object’s is_secure() method. Set this to ('HTTP_X_FORWARDED_PROTO', 'https') to tell Django to use the
+# X-Forwarded-Proto header to tell whether the service is served over TLS or not. This can be used, e.g., when a proxy
+# terminates the TLS connection and forwards the request over an unsecure HTTP connection. If a proxy is in use and
+# this is disabled, the links in the Browsable API may show http as the scheme instead of https.
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
+SECURE_PROXY_SSL_HEADER = env('SECURE_PROXY_SSL_HEADER')
 
 #
 # Authentication

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -49,6 +49,8 @@ env = environ.Env(
     ADMINS=(list, []),
     SECURE_PROXY_SSL_HEADER=(tuple, None),
     USE_X_FORWARDED_HOST=(bool, False),
+    CUSTOM_X_FORWARDED_PORT_HEADER=(str, 'LINKEDEVENTS-X-FORWARDED-PORT'),
+    CUSTOM_X_FORWARDED_PROTO_HEADER=(str, 'LINKEDEVENTS-X-FORWARDED-PROTO'),
     MEDIA_ROOT=(environ.Path(), root('media')),
     STATIC_ROOT=(environ.Path(), root('static')),
     MEDIA_URL=(str, '/media/'),
@@ -209,6 +211,7 @@ if env('SENTRY_DSN'):
     )
 
 MIDDLEWARE = [
+    'linkedevents.middleware.AwsAlbHeaderMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -292,6 +295,11 @@ USE_X_FORWARDED_HOST = env('USE_X_FORWARDED_HOST')
 # this is disabled, the links in the Browsable API may show http as the scheme instead of https.
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
 SECURE_PROXY_SSL_HEADER = env('SECURE_PROXY_SSL_HEADER')
+
+# Define the custom headers from which the X-Forwarded-{Port|Proto} header values will be copied. See middlewares.py
+# for more details.
+CUSTOM_X_FORWARDED_PORT_HEADER = env('CUSTOM_X_FORWARDED_PORT_HEADER')
+CUSTOM_X_FORWARDED_PROTO_HEADER = env('CUSTOM_X_FORWARDED_PROTO_HEADER')
 
 #
 # Authentication


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

The hostname is not shown correctly, e.g., in the browsable API when the service is behind a proxy. Thus, we need to pass X-Forwarded-Host and X-Forwarded-Proto headers for the hostname to be built correctly by Django.

[ES-135]

#### Dependencies
<!-- Describe the dependencies the change has on other repositories, pull requests etc. -->

#### Testing instructions
<!-- Describe how the change can be tested, e.g., steps and tools to use -->

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)
- [x] The commits and commit messages adhere to [version control conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
- [ ] ~The API's adhere to Voltti's REST API conventions~
- [x] The code is consistent with the existing code base
- [ ] Tests have been written for the change (unit, REST API)
- [x] All tests pass
- [x] All code has been linted and there aren't any lint errors
- [x] The change has been tested locally, e.g., with httpie
- [ ] ~The change has been tested against a DB dump from test and/or staging if the models have been changed~
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)
- [ ] The commits and commit messages adhere to [version control conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
- [ ] The API's adhere to Voltti's REST API conventions
- [ ] The code is consistent with the existing code base
- [ ] All changes in all changed files have been reviewed
- [ ] Tests have been written for the change (unit, REST API)
- [ ] All tests pass
- [ ] All code has been linted and there aren't any lint errors
- [ ] The change has been tested locally, e.g., with httpie
- [ ] The change has been tested against a DB dump from test and/or staging if the models have been changed
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```


[ES-135]: https://voltti.atlassian.net/browse/ES-135