### PR TITLE
[ES-145]: Fix app throwing an exception when email isn't configured

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -643,7 +643,10 @@ class Event(MPTTModel, BaseModel, SchemalessFieldMixin, ReplacedByMixin):
         if old_location and self.location and old_location != self.location:
             Place.objects.filter(id__in=(old_location.id, self.location.id)).update(n_events_changed=True)
 
-        # send notifications
+        # Send notifications only if notifications are enabled
+        if not settings.ENABLE_NOTIFICATIONS:
+            return
+
         if old_publication_status == PublicationStatus.DRAFT and self.publication_status == PublicationStatus.PUBLIC:
             self.send_published_notification()
         if self.publication_status == PublicationStatus.DRAFT and (old_deleted is False and self.deleted is True):

--- a/events/signals.py
+++ b/events/signals.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.core.mail import send_mail
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
@@ -22,6 +23,10 @@ def organization_post_save(sender, instance, created, **kwargs):
 
 
 def user_post_save(sender, instance, created, **kwargs):
+    # Send notifications only if notifications are enabled
+    if not settings.ENABLE_NOTIFICATIONS:
+        return
+
     if created:
         User = get_user_model()
         recipient_list = [item[0] for item in User.objects.filter(is_superuser=True).values_list('email')]

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -74,6 +74,8 @@ env = environ.Env(
     AWS_MEDIA_STORAGE_BUCKET_NAME=(str, ''),
     AWS_MEDIA_DEFAULT_ACL=(str, None),
     AWS_MEDIA_S3_CUSTOM_DOMAIN=(str, ''),
+    # Enabling notifications requires that email has been configured
+    ENABLE_NOTIFICATIONS=(bool, False),
 )
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -542,6 +544,8 @@ if 'SECRET_KEY' not in locals() or not SECRET_KEY:
             secret.close()
         except IOError:
             Exception('Please create a %s file with random characters to generate your secret key!' % secret_file)
+
+ENABLE_NOTIFICATIONS = env('ENABLE_NOTIFICATIONS')
 
 #
 # Anymail

--- a/linkedevents/test.py
+++ b/linkedevents/test.py
@@ -22,6 +22,8 @@ DATABASES = {
     'default': env.db()
 }
 
+ENABLE_NOTIFICATIONS = True
+
 
 def dummy_haystack_connection_without_warnings_for_lang(language_code):
     return {f'default-{language_code}': {


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

[ES-145]

#### Dependencies
<!-- Describe the dependencies the change has on other repositories, pull requests etc. -->

#### Testing instructions
<!-- Describe how the change can be tested, e.g., steps and tools to use -->

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)
- [x] The commits and commit messages adhere to [version control conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
- [ ] ~The API's adhere to Voltti's REST API conventions~
- [x] The code is consistent with the existing code base
- [ ] Tests have been written for the change (unit, REST API)
- [x] All tests pass
- [x] All code has been linted and there aren't any lint errors
- [x] The change has been tested locally, e.g., with httpie
- [ ] ~The change has been tested against a DB dump from test and/or staging if the models have been changed~
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)
- [ ] The commits and commit messages adhere to [version control conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
- [ ] The API's adhere to Voltti's REST API conventions
- [ ] The code is consistent with the existing code base
- [ ] All changes in all changed files have been reviewed
- [ ] Tests have been written for the change (unit, REST API)
- [ ] All tests pass
- [ ] All code has been linted and there aren't any lint errors
- [ ] The change has been tested locally, e.g., with httpie
- [ ] The change has been tested against a DB dump from test and/or staging if the models have been changed
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```


[ES-145]: https://voltti.atlassian.net/browse/ES-145