### PR TITLE
[ES-206]: Fix failing tests

### DIFF
--- a/events/tests/test_event_post.py
+++ b/events/tests/test_event_post.py
@@ -282,8 +282,11 @@ def test__autopopulated_fields_at_create(
     assert event.data_source.id == settings.SYSTEM_DATA_SOURCE_ID
     assert event.publisher == organization
     # events are automatically marked as ending at midnight, local time
-    assert event.end_time == timezone.localtime(timezone.now() + timedelta(days=2)).\
-        replace(hour=0, minute=0, second=0, microsecond=0).astimezone(pytz.utc)
+    expected_end_time = (
+        timezone.localtime(event.start_time).replace(hour=0, minute=0, second=0, microsecond=0)
+        .astimezone(pytz.utc) + timedelta(days=1)
+    )
+    assert event.end_time == expected_end_time
     assert event.has_end_time is False
 
 

--- a/events/tests/test_event_put.py
+++ b/events/tests/test_event_put.py
@@ -192,8 +192,11 @@ def test__update_minimal_event_with_autopopulated_fields_with_put(api_client, mi
     assert event.data_source.id == settings.SYSTEM_DATA_SOURCE_ID
     assert event.publisher == organization
     # events are automatically marked as ending at midnight, local time
-    assert event.end_time == timezone.localtime(timezone.now() + timedelta(days=2)).\
-        replace(hour=0, minute=0, second=0, microsecond=0).astimezone(pytz.utc)
+    expected_end_time = (
+        timezone.localtime(event.start_time).replace(hour=0, minute=0, second=0, microsecond=0)
+        .astimezone(pytz.utc) + timedelta(days=1)
+    )
+    assert event.end_time == expected_end_time
     assert event.has_end_time is False
 
 


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

Two tests are failing due to datetime calculations that differ from the actual implementation. The calculations in the tests don't take daylight saving time correctly into account. This commit fixes the issue by calculating the expected end_time in the tests in the same way as the implementation calculates the automatic end_time.

[ES-206]

#### Dependencies
<!-- Describe the dependencies the change has on other repositories, pull requests etc. -->

#### Testing instructions
<!-- Describe how the change can be tested, e.g., steps and tools to use -->

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)
- [x] The commits and commit messages adhere to [version control conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
- [ ] ~The API's adhere to Voltti's REST API conventions~
- [x] The code is consistent with the existing code base
- [ ] ~Tests have been written for the change (unit, REST API)~
- [x] All tests pass
- [x] All code has been linted and there aren't any lint errors
- [x] The change has been tested locally, e.g., with httpie
- [ ] ~The change has been tested against a DB dump from test and/or staging if the models have been changed~
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)
- [ ] The commits and commit messages adhere to [version control conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
- [ ] The API's adhere to Voltti's REST API conventions
- [ ] The code is consistent with the existing code base
- [ ] All changes in all changed files have been reviewed
- [ ] Tests have been written for the change (unit, REST API)
- [ ] All tests pass
- [ ] All code has been linted and there aren't any lint errors
- [ ] The change has been tested locally, e.g., with httpie
- [ ] The change has been tested against a DB dump from test and/or staging if the models have been changed
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```


[ES-206]: https://voltti.atlassian.net/browse/ES-206