### PR TITLE
[ES-226]: Check for secrets only in current branch

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,5 +1,7 @@
 #### Helper scripts to automate commit linting and security checks
 
-The hook scripts in *.d directories were created taking the output of `gitlint` and `git-secrets` and sorting them neatly into subdirectories.
+The hook scripts in *.d directories were created taking the output of `gitlint` and `git-secrets` and sorting them
+neatly into subdirectories.
 
-The root hook script is taken from https://gist.github.com/mjackson/7e602a7aa357cfe37dadcc016710931b and does a decent job in running the various scripts
+The root hook script is taken from https://gist.github.com/mjackson/7e602a7aa357cfe37dadcc016710931b and does a decent
+job in running the various scripts.

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -6,7 +6,8 @@
 # It looks for scripts in the .git/hooks/pre-receive.d directory and executes them in order,
 # passing along stdin. If any script exits with a non-zero status, this script exits.
 
-script_dir=$(dirname "$0")
+# Since this file is symlinked, we need to get the actual directory where the symlinked file is
+script_dir="$(dirname "$(readlink -f "$0")")"
 hook_name=$(basename "$0")
 
 hook_dir="$script_dir/$hook_name.d"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,7 +6,8 @@
 # It looks for scripts in the .git/hooks/pre-receive.d directory and executes them in order,
 # passing along stdin. If any script exits with a non-zero status, this script exits.
 
-script_dir=$(dirname "$0")
+# Since this file is symlinked, we need to get the actual directory where the symlinked file is
+script_dir="$(dirname "$(readlink -f "$0")")"
 hook_name=$(basename "$0")
 
 hook_dir="$script_dir/$hook_name.d"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,7 +6,8 @@
 # It looks for scripts in the .git/hooks/pre-receive.d directory and executes them in order,
 # passing along stdin. If any script exits with a non-zero status, this script exits.
 
-script_dir=$(dirname "$0")
+# Since this file is symlinked, we need to get the actual directory where the symlinked file is
+script_dir="$(dirname "$(readlink -f "$0")")"
 hook_name=$(basename "$0")
 
 hook_dir="$script_dir/$hook_name.d"

--- a/.githooks/pre-push.d/01-trufflehog
+++ b/.githooks/pre-push.d/01-trufflehog
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-trufflehog --since_commit "$(git rev-parse master)" --regex --exclude_paths trufflehog-exclude-patterns.txt .
+trufflehog --branch "$(git rev-parse --abbrev-ref HEAD)" --max_depth "$(git rev-list --count master..HEAD)" --regex --exclude_paths trufflehog-exclude-patterns.txt .

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -6,7 +6,8 @@
 # It looks for scripts in the .git/hooks/pre-receive.d directory and executes them in order,
 # passing along stdin. If any script exits with a non-zero status, this script exits.
 
-script_dir=$(dirname "$0")
+# Since this file is symlinked, we need to get the actual directory where the symlinked file is
+script_dir="$(dirname "$(readlink -f "$0")")"
 hook_name=$(basename "$0")
 
 hook_dir="$script_dir/$hook_name.d"

--- a/bin/git-hooks.sh
+++ b/bin/git-hooks.sh
@@ -26,7 +26,10 @@ git secrets --register-aws
 echo "Setting scripts to be executable."
 find .githooks -type f -print0 | xargs chmod +x
 
-echo "Copying files to Git Hooks directory."
-cp -R .githooks/. .git/hooks/
+echo "Creating symlinks to git hook files"
+ln -s ../../.githooks/commit-msg .git/hooks/commit-msg
+ln -s ../../.githooks/pre-commit .git/hooks/pre-commit
+ln -s ../../.githooks/pre-push .git/hooks/pre-push
+ln -s ../../.githooks/prepare-commit-msg .git/hooks/prepare-commit-msg
 
 echo "Done!"


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->

Trufflehog's --since_commit option doesn't seem to work properly (see https://github.com/dxa4481/truffleHog/issues/108). Instead, search for secrets only in the current feature branch's commits by using the --branch and --max_depth options. Semantically, this ought to be the same as using --since_commit.

[ES-226]

#### Dependencies
<!-- Describe the dependencies the change has on other repositories, pull requests etc. -->

#### Testing instructions
<!-- Describe how the change can be tested, e.g., steps and tools to use -->

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)
- [x] The commits and commit messages adhere to [version control conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
- [ ] ~The API's adhere to Voltti's REST API conventions~
- [x] The code is consistent with the existing code base
- [ ] ~Tests have been written for the change (unit, REST API)~
- [x] All tests pass
- [x] All code has been linted and there aren't any lint errors
- [x] The change has been tested locally, e.g., with httpie
- [ ] ~The change has been tested against a DB dump from test and/or staging if the models have been changed~
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)
- [ ] The commits and commit messages adhere to [version control conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
- [ ] The API's adhere to Voltti's REST API conventions
- [ ] The code is consistent with the existing code base
- [ ] All changes in all changed files have been reviewed
- [ ] Tests have been written for the change (unit, REST API)
- [ ] All tests pass
- [ ] All code has been linted and there aren't any lint errors
- [ ] The change has been tested locally, e.g., with httpie
- [ ] The change has been tested against a DB dump from test and/or staging if the models have been changed
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The PR branch has been rebased against master and force pushed if necessary before merging
```


[ES-226]: https://voltti.atlassian.net/browse/ES-226