### PR TITLE
Revert "chore(deps): bump pillow from 8.2.0 to 9.0.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -153,7 +153,7 @@ oauthlib==3.1.0
     # via requests-oauthlib
 packaging==20.4
     # via bleach
-pillow==9.0.1
+pillow==8.2.0
     # via
     #   -r requirements.in
     #   easy-thumbnails


### PR DESCRIPTION
Reverts espoon-voltti/espooevents-service#81, install errors found afterwards