### PR TITLE
fix: sv term change as requested

### DIFF
--- a/events/management/commands/add_espoo_audience.py
+++ b/events/management/commands/add_espoo_audience.py
@@ -67,7 +67,7 @@ CUSTOM_ESPOO_AUDIENCE_KEYWORDS = [
     {
         'id': 'espoo:a5',
         'name_fi': 'vammaiset',
-        'name_sv': 'handikappade',
+        'name_sv': 'funktionsnedsatta',
         'name_en': 'disabled',
         'data_source_id': ESPOO_DATA_SOURCE_ID,
     },


### PR DESCRIPTION
There is no migration

`update events_keyword set name_sv ='funktionsnedsatta' where id = 'espoo:a5';`
