### PR TITLE
fix: use older distro for admin fixing broken import_osoite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
           build-args: |
             build=${{ github.run_number }}
             commit=${{ github.sha }}
-            BASE_IMAGE_VERSION=3.7.12-slim
+            BASE_IMAGE_VERSION=3.7.12-slim-buster
 
   tag:
     if: github.ref == 'refs/heads/master'

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build_dist:
 .PHONY: build_admin
 build_admin:
 	@docker build \
-	--build-arg BASE_IMAGE_VERSION=3.7-slim \
+	--build-arg BASE_IMAGE_VERSION=3.7.12-slim-buster \
 	--target admin \
 	-f Dockerfile.dist \
 	-t linkedevents-admin \


### PR DESCRIPTION
change between libgeos 3.7.1 and 3.9.0 apparently fixed swapped coordinate order bug with munigeo-helsinki used by us


