### PR TITLE
fix: add subevent  timing validation

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -1582,6 +1582,24 @@ class EventSerializer(BulkSerializerMixin, EditableLinkedEventsObjectSerializer,
         links = validated_data.pop('external_links', None)
         videos = validated_data.pop('videos', None)
 
+        if instance.super_event is not None and (
+            (
+                instance.super_event.start_time
+                and instance.start_time
+                and instance.start_time < instance.super_event.start_time
+            )
+            or (
+                instance.super_event.end_time
+                and instance.end_time
+                and instance.end_time > instance.super_event.end_time
+            )
+        ):
+            raise DRFPermissionDenied(
+                _(
+                    "Cannot set sub event to start before super event start or end after super event end."
+                )
+            )
+
         if instance.end_time and instance.end_time < timezone.now() and not self.data_source.edit_past_events:
             raise DRFPermissionDenied(_('Cannot edit a past event.'))
 

--- a/events/api.py
+++ b/events/api.py
@@ -1581,8 +1581,8 @@ class EventSerializer(BulkSerializerMixin, EditableLinkedEventsObjectSerializer,
         offers = validated_data.pop('offers', None)
         links = validated_data.pop('external_links', None)
         videos = validated_data.pop('videos', None)
-        start_time = validated_data.pop('start_time', None)
-        end_time = validated_data.pop('end_time', None)
+        start_time = validated_data.get('start_time', None)
+        end_time = validated_data.get('end_time', None)
 
         if instance.super_event is not None and (
             (

--- a/events/api.py
+++ b/events/api.py
@@ -1581,22 +1581,24 @@ class EventSerializer(BulkSerializerMixin, EditableLinkedEventsObjectSerializer,
         offers = validated_data.pop('offers', None)
         links = validated_data.pop('external_links', None)
         videos = validated_data.pop('videos', None)
+        start_time = validated_data.pop('start_time', None)
+        end_time = validated_data.pop('end_time', None)
 
         if instance.super_event is not None and (
             (
                 instance.super_event.start_time
-                and instance.start_time
-                and instance.start_time < instance.super_event.start_time
+                and start_time is not None
+                and start_time < instance.super_event.start_time
             )
             or (
                 instance.super_event.end_time
-                and instance.end_time
-                and instance.end_time > instance.super_event.end_time
+                and end_time is not None
+                and end_time > instance.super_event.end_time
             )
         ):
             raise DRFPermissionDenied(
                 _(
-                    "Cannot set sub event to start before super event start or end after super event end."
+                    'Cannot set sub event to start before super event start or end  after super event end.'
                 )
             )
 


### PR DESCRIPTION
### Before this change:
- Sub event scheduling had no restriction

### After this change:
- Sub events can't be set to start before their respective super events nor can they be set end after their super events.
- In case such an update is tried the server responds with `403: "Cannot set sub event to start before super event start or end after super event end."`
