### PR TITLE
fix: Add validation to date published

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -1581,26 +1581,31 @@ class EventSerializer(BulkSerializerMixin, EditableLinkedEventsObjectSerializer,
         videos = validated_data.pop('videos', None)
         start_time = validated_data.get('start_time', None)
         end_time = validated_data.get('end_time', None)
+        date_published = validated_data.get('date_published', None)
         super_event = validated_data.pop('super_event', None)
 
-        if instance.super_event is not None and (
-            (
-                instance.super_event.start_time
-                and start_time is not None
-                and start_time < instance.super_event.start_time
-            )
-            or (
-                instance.super_event.end_time
-                and end_time is not None
-                and end_time > instance.super_event.end_time
-            )
-        ):
-            raise DRFPermissionDenied(
-                _(
-                    'Cannot set sub event to start before super event start or end  after super event end.'
+        if instance.super_event is not None:
+            if ((instance.super_event.start_time
+                 and start_time is not None
+                 and start_time < instance.super_event.start_time)
+                or (instance.super_event.end_time
+                    and end_time is not None
+                    and end_time > instance.super_event.end_time)):
+                raise DRFPermissionDenied(
+                    _(
+                        'Cannot set sub event to start before super event start or end  after super event end.'
+                    )
                 )
-            )
-
+            if (
+                    instance.super_event.date_published
+                    and date_published
+                    and date_published < instance.super_event.date_published
+            ):
+                raise DRFPermissionDenied(
+                    _(
+                        'Cannot set sub event to date published before super event date published.'
+                    )
+                )
         if instance.end_time and instance.end_time < timezone.now() and not self.data_source.edit_past_events:
             raise DRFPermissionDenied(_('Cannot edit a past event.'))
 

--- a/events/api.py
+++ b/events/api.py
@@ -40,7 +40,6 @@ from rest_framework import (filters, generics, mixins, permissions, relations,
                             serializers, status, viewsets)
 from rest_framework.exceptions import APIException, ParseError
 from rest_framework.exceptions import PermissionDenied as DRFPermissionDenied
-from rest_framework.exceptions import BadRequest
 from rest_framework.fields import DateTimeField
 from rest_framework.filters import BaseFilterBackend
 from rest_framework.permissions import SAFE_METHODS
@@ -1592,23 +1591,15 @@ class EventSerializer(BulkSerializerMixin, EditableLinkedEventsObjectSerializer,
                 or (instance.super_event.end_time
                     and end_time is not None
                     and end_time > instance.super_event.end_time)):
-                raise BadRequest(
-                    _(
-                        'Cannot set sub event to start before super event start or end  after super event end.'
-                    )
-                )
+                raise serializers.ValidationError('TIME_MISMATCH_ERROR')
             if (
                     instance.super_event.date_published
                     and date_published
                     and date_published < instance.super_event.date_published
             ):
-                raise BadRequest(
-                    _(
-                        'Cannot set sub event to date published before super event date published.'
-                    )
-                )
+                raise serializers.ValidationError('DATE_PUBLISHED_INVALID_ERROR')
         if instance.end_time and instance.end_time < timezone.now() and not self.data_source.edit_past_events:
-            raise BadRequest(_('Cannot edit a past event.'))
+            raise serializers.ValidationError('PAST_EVENT_EDIT_ERROR')
 
         # The API only allows scheduling and cancelling events.
         # POSTPONED and RESCHEDULED may not be set, but should be allowed in already set instances.

--- a/events/api.py
+++ b/events/api.py
@@ -40,6 +40,7 @@ from rest_framework import (filters, generics, mixins, permissions, relations,
                             serializers, status, viewsets)
 from rest_framework.exceptions import APIException, ParseError
 from rest_framework.exceptions import PermissionDenied as DRFPermissionDenied
+from rest_framework.exceptions import BadRequest
 from rest_framework.fields import DateTimeField
 from rest_framework.filters import BaseFilterBackend
 from rest_framework.permissions import SAFE_METHODS
@@ -1591,7 +1592,7 @@ class EventSerializer(BulkSerializerMixin, EditableLinkedEventsObjectSerializer,
                 or (instance.super_event.end_time
                     and end_time is not None
                     and end_time > instance.super_event.end_time)):
-                raise DRFPermissionDenied(
+                raise BadRequest(
                     _(
                         'Cannot set sub event to start before super event start or end  after super event end.'
                     )
@@ -1601,13 +1602,13 @@ class EventSerializer(BulkSerializerMixin, EditableLinkedEventsObjectSerializer,
                     and date_published
                     and date_published < instance.super_event.date_published
             ):
-                raise DRFPermissionDenied(
+                raise BadRequest(
                     _(
                         'Cannot set sub event to date published before super event date published.'
                     )
                 )
         if instance.end_time and instance.end_time < timezone.now() and not self.data_source.edit_past_events:
-            raise DRFPermissionDenied(_('Cannot edit a past event.'))
+            raise BadRequest(_('Cannot edit a past event.'))
 
         # The API only allows scheduling and cancelling events.
         # POSTPONED and RESCHEDULED may not be set, but should be allowed in already set instances.

--- a/events/tests/test_event_put.py
+++ b/events/tests/test_event_put.py
@@ -773,8 +773,8 @@ def test_cannot_edit_events_in_the_past(api_client, event, minimal_event_dict, u
     event.save(update_fields=('start_time', 'end_time'))
 
     response = api_client.put(reverse('event-detail', kwargs={'pk': event.id}), minimal_event_dict, format='json')
-    assert response.status_code == 403
-    assert 'Cannot edit a past event' in str(response.content)
+    assert response.status_code == 400
+    assert 'PAST_EVENT_EDIT_ERROR' in str(response.content)
 
 
 @pytest.mark.django_db
@@ -797,8 +797,8 @@ def test_cannot_edit_sub_events_to_start_before_super_event_start(api_client, mi
 
     response = update_with_put(api_client, sub_event_id, sub_event)
 
-    assert response.status_code == 403
-    returnstring = "Cannot set sub event to start before super event start or end  after super event end."
+    assert response.status_code == 400
+    returnstring = 'TIME_MISMATCH_ERROR'
     assert returnstring in str(response.content)
 
 
@@ -822,8 +822,33 @@ def test_cannot_edit_sub_events_to_end_after_super_event_end(api_client, minimal
 
     response = update_with_put(api_client, sub_event_id, sub_event)
 
-    assert response.status_code == 403
-    returnstring = "Cannot set sub event to start before super event start or end  after super event end."
+    assert response.status_code == 400
+    returnstring = 'TIME_MISMATCH_ERROR'
+    assert returnstring in str(response.content)
+
+
+@pytest.mark.django_db
+def test_cannot_sub_event_to_be_published_before_the_super_event(api_client, minimal_event_dict, user):
+    api_client.force_authenticate(user)
+    minimal_event_dict['date_published'] = (datetime.now() + timedelta(days=2)).isoformat()
+    sub_event_dict = deepcopy(minimal_event_dict)
+    minimal_event_dict['super_event_type'] = Event.SuperEventType.RECURRING
+
+    response = create_with_post(api_client, minimal_event_dict)
+    super_event_url = response.data['@id']
+
+    sub_event_dict['super_event'] = {'@id': super_event_url}
+    sub_event_dict['name']['fi'] = 'sub event 1'
+
+    response = create_with_post(api_client, sub_event_dict)
+    sub_event = response.data
+    sub_event['date_published'] = (datetime.now() + timedelta(days=1)).isoformat()
+    sub_event_id = sub_event.pop('@id')
+
+    response = update_with_put(api_client, sub_event_id, sub_event)
+
+    assert response.status_code == 400
+    returnstring = 'DATE_PUBLISHED_INVALID_ERROR'
     assert returnstring in str(response.content)
 
 


### PR DESCRIPTION
### After this change:
- sub event `date_published` can no longer be set before super event `date_published`