### PR TITLE
Fix: some hobby categrories not showing in dropdown enu

### DIFF
--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -346,7 +346,7 @@ SOCIALACCOUNT_ADAPTER = 'helusers.adapter.SocialAccountAdapter'
 # REST Framework
 #
 REST_FRAMEWORK = {
-    'PAGE_SIZE': 20,
+    'PAGE_SIZE': 30,
     'ORDERING_PARAM': 'sort',
     'DEFAULT_RENDERER_CLASSES': (
         'events.renderers.JSONRenderer',


### PR DESCRIPTION
### After this change:
- Rest framework page size has been raised to 30 to get all hobby categories on a single page
